### PR TITLE
CN-804: Harden invoice URL config against SSRF/MITM

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - Invoice
 ===========
+### 3.1.5 (2026-07-20)
+* CN-804: Hardened invoice URL config to require https and reject private/loopback/link-local hosts; explicitly enforce TLS verification on invoice send
+
 ### 3.1.3 (2025-02-26)
 * CN-546:   Updated composer.json file to removed version restrictions
 * PBR-2329: Added ACL support for Role management

--- a/Model/InvoiceService/InvoiceSender.php
+++ b/Model/InvoiceService/InvoiceSender.php
@@ -47,6 +47,7 @@ class InvoiceSender implements InvoiceSenderInterface
             'headers' => $request->getHeaders(),
             'json' => $request->getParams(),
             'verify' => true,
+            'allow_redirects' => false,
         ]);
 
         return $this->resultFactory->create(['response' => $response]);

--- a/Model/InvoiceService/InvoiceSender.php
+++ b/Model/InvoiceService/InvoiceSender.php
@@ -46,6 +46,7 @@ class InvoiceSender implements InvoiceSenderInterface
         $response = $client->request('POST', $request->getUri(), [
             'headers' => $request->getHeaders(),
             'json' => $request->getParams(),
+            'verify' => true,
         ]);
 
         return $this->resultFactory->create(['response' => $response]);

--- a/Model/System/Config/Backend/Url.php
+++ b/Model/System/Config/Backend/Url.php
@@ -125,7 +125,7 @@ class Url extends Value
      * @param string $host
      * @return string[]
      */
-    private function resolveHost(string $host): array
+    protected function resolveHost(string $host): array
     {
         // dns_get_record() emits a warning when a record type can't be resolved;
         // that's an expected outcome here, not an error to surface.

--- a/Model/System/Config/Backend/Url.php
+++ b/Model/System/Config/Backend/Url.php
@@ -79,10 +79,20 @@ class Url extends Value
      */
     private function resolveHost(string $host): array
     {
-        $records = array_merge(
-            @dns_get_record($host, DNS_A) ?: [],
-            @dns_get_record($host, DNS_AAAA) ?: []
-        );
+        // dns_get_record() emits a warning when a record type can't be resolved;
+        // that's an expected outcome here, not an error to surface.
+        set_error_handler(static function (): bool {
+            return true;
+        });
+
+        try {
+            $records = array_merge(
+                dns_get_record($host, DNS_A) ?: [],
+                dns_get_record($host, DNS_AAAA) ?: []
+            );
+        } finally {
+            restore_error_handler();
+        }
 
         $ips = [];
         foreach ($records as $record) {

--- a/Model/System/Config/Backend/Url.php
+++ b/Model/System/Config/Backend/Url.php
@@ -36,7 +36,10 @@ class Url extends Value
             throw new LocalizedException(__('Invoice URL must use the https scheme.'));
         }
 
-        if ($this->isDisallowedHost($parts['host'])) {
+        // parse_url() keeps the enclosing brackets on an IPv6 host (e.g. "[::1]").
+        $host = trim($parts['host'], '[]');
+
+        if ($this->isDisallowedHost($host)) {
             throw new LocalizedException(
                 __('Invoice URL may not point to a private, loopback, or link-local address.')
             );
@@ -51,14 +54,41 @@ class Url extends Value
      */
     private function isDisallowedHost(string $host): bool
     {
-        $isLiteralIp = (bool) filter_var($host, FILTER_VALIDATE_IP);
-        $ip = $isLiteralIp ? $host : gethostbyname($host);
+        $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : $this->resolveHost($host);
 
-        if (!$isLiteralIp && $ip === $host) {
-            // DNS resolution failed - fail closed rather than silently allow.
+        if (empty($ips)) {
+            // No IP literal and no DNS resolution - fail closed rather than silently allow.
             return true;
         }
 
-        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+        foreach (array_unique($ips) as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve both A and AAAA records so an allowed public IPv4 address
+     * can't mask a disallowed private/reserved IPv6 address (or vice versa).
+     *
+     * @param string $host
+     * @return string[]
+     */
+    private function resolveHost(string $host): array
+    {
+        $records = array_merge(
+            @dns_get_record($host, DNS_A) ?: [],
+            @dns_get_record($host, DNS_AAAA) ?: []
+        );
+
+        $ips = [];
+        foreach ($records as $record) {
+            $ips[] = $record['ip'] ?? $record['ipv6'] ?? null;
+        }
+
+        return array_values(array_filter($ips));
     }
 }

--- a/Model/System/Config/Backend/Url.php
+++ b/Model/System/Config/Backend/Url.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace TradeCentric\Invoice\Model\System\Config\Backend;
+
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Validates the TradeCentric invoice export URL on save to require an
+ * encrypted transport (mitigating MITM) and block private/loopback/
+ * link-local hosts (mitigating SSRF via config misconfiguration) (CN-804).
+ */
+class Url extends Value
+{
+    const ALLOWED_SCHEMES = ['https'];
+
+    /**
+     * @return $this
+     * @throws LocalizedException
+     */
+    public function beforeSave()
+    {
+        $url = trim((string) $this->getValue());
+
+        if ($url === '') {
+            return parent::beforeSave();
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            throw new LocalizedException(__('Invoice URL is not a valid URL.'));
+        }
+
+        if (!in_array(strtolower($parts['scheme']), self::ALLOWED_SCHEMES, true)) {
+            throw new LocalizedException(__('Invoice URL must use the https scheme.'));
+        }
+
+        if ($this->isDisallowedHost($parts['host'])) {
+            throw new LocalizedException(
+                __('Invoice URL may not point to a private, loopback, or link-local address.')
+            );
+        }
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * @param string $host
+     * @return bool
+     */
+    private function isDisallowedHost(string $host): bool
+    {
+        $isLiteralIp = (bool) filter_var($host, FILTER_VALIDATE_IP);
+        $ip = $isLiteralIp ? $host : gethostbyname($host);
+
+        if (!$isLiteralIp && $ip === $host) {
+            // DNS resolution failed - fail closed rather than silently allow.
+            return true;
+        }
+
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+    }
+}

--- a/Model/System/Config/Backend/Url.php
+++ b/Model/System/Config/Backend/Url.php
@@ -3,17 +3,57 @@ declare(strict_types=1);
 
 namespace TradeCentric\Invoice\Model\System\Config\Backend;
 
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Value;
+use Magento\Framework\App\State;
+use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
 
 /**
  * Validates the TradeCentric invoice export URL on save to require an
  * encrypted transport (mitigating MITM) and block private/loopback/
  * link-local hosts (mitigating SSRF via config misconfiguration) (CN-804).
+ *
+ * The private/loopback/link-local host restriction is skipped in Magento's
+ * Developer mode so local development can point this at a local mock
+ * endpoint; the https scheme requirement is enforced in every mode.
  */
 class Url extends Value
 {
     const ALLOWED_SCHEMES = ['https'];
+
+    /**
+     * @var State
+     */
+    private $appState;
+
+    /**
+     * @param Context $context
+     * @param Registry $registry
+     * @param ScopeConfigInterface $config
+     * @param TypeListInterface $cacheTypeList
+     * @param State $appState
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        State $appState,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        $this->appState = $appState;
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
 
     /**
      * @return $this
@@ -39,13 +79,21 @@ class Url extends Value
         // parse_url() keeps the enclosing brackets on an IPv6 host (e.g. "[::1]").
         $host = trim($parts['host'], '[]');
 
-        if ($this->isDisallowedHost($host)) {
+        if (!$this->isDeveloperMode() && $this->isDisallowedHost($host)) {
             throw new LocalizedException(
                 __('Invoice URL may not point to a private, loopback, or link-local address.')
             );
         }
 
         return parent::beforeSave();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isDeveloperMode(): bool
+    {
+        return $this->appState->getMode() === State::MODE_DEVELOPER;
     }
 
     /**

--- a/Test/Unit/Model/System/Config/Backend/UrlTest.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlTest.php
@@ -113,6 +113,25 @@ class UrlTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testBeforeSaveAllowsHostnameThatResolvesToPublicIp(): void
+    {
+        $model = $this->createModelWithStubbedDns('https://mock-invoice-endpoint.test/invoice', ['93.184.216.34']);
+        $model->beforeSave();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBeforeSaveRejectsHostnameThatResolvesToPrivateIp(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->createModelWithStubbedDns('https://mock-invoice-endpoint.test/invoice', ['10.0.0.5'])->beforeSave();
+    }
+
+    /**
      * @param string $value
      * @param string $mode
      * @return Url
@@ -126,6 +145,25 @@ class UrlTest extends TestCase
         /** @var Url $model */
         $model = $objectManager->getObject(Url::class, ['appState' => $appState]);
         $model->setValue($value);
+
+        return $model;
+    }
+
+    /**
+     * @param string $value
+     * @param string[] $ips
+     * @return UrlWithStubbedDns
+     */
+    private function createModelWithStubbedDns(string $value, array $ips): UrlWithStubbedDns
+    {
+        $appState = $this->createMock(State::class);
+        $appState->method('getMode')->willReturn(State::MODE_DEFAULT);
+
+        $objectManager = new ObjectManager($this);
+        /** @var UrlWithStubbedDns $model */
+        $model = $objectManager->getObject(UrlWithStubbedDns::class, ['appState' => $appState]);
+        $model->setValue($value);
+        $model->setStubbedIps($ips);
 
         return $model;
     }

--- a/Test/Unit/Model/System/Config/Backend/UrlTest.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TradeCentric\Invoice\Test\Unit\Model\System\Config\Backend;
 
+use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
@@ -70,13 +71,60 @@ class UrlTest extends TestCase
 
     /**
      * @param string $value
+     * @return void
+     * @dataProvider developerModeAllowedHostDataProvider
+     */
+    public function testBeforeSaveAllowsPrivateAndLoopbackHostsInDeveloperMode(string $value): void
+    {
+        $model = $this->createModel($value, State::MODE_DEVELOPER);
+        $model->beforeSave();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array
+     */
+    public function developerModeAllowedHostDataProvider(): array
+    {
+        return [
+            'loopback ip' => ['https://127.0.0.1/invoice'],
+            'link-local ip' => ['https://169.254.169.254/latest/meta-data'],
+            'private ip 192.168.x' => ['https://192.168.0.5/invoice'],
+            'ipv6 loopback literal' => ['https://[::1]/invoice'],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testBeforeSaveStillRejectsNonHttpsInDeveloperMode(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->createModel('http://127.0.0.1/invoice', State::MODE_DEVELOPER)->beforeSave();
+    }
+
+    /**
+     * @return void
+     */
+    public function testBeforeSaveStillRejectsMalformedUrlInDeveloperMode(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->createModel('not-a-url', State::MODE_DEVELOPER)->beforeSave();
+    }
+
+    /**
+     * @param string $value
+     * @param string $mode
      * @return Url
      */
-    private function createModel(string $value): Url
+    private function createModel(string $value, string $mode = State::MODE_DEFAULT): Url
     {
+        $appState = $this->createMock(State::class);
+        $appState->method('getMode')->willReturn($mode);
+
         $objectManager = new ObjectManager($this);
         /** @var Url $model */
-        $model = $objectManager->getObject(Url::class);
+        $model = $objectManager->getObject(Url::class, ['appState' => $appState]);
         $model->setValue($value);
 
         return $model;

--- a/Test/Unit/Model/System/Config/Backend/UrlTest.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlTest.php
@@ -30,8 +30,8 @@ class UrlTest extends TestCase
     {
         return [
             'empty value is allowed' => [''],
-            'public https host' => ['https://api.tradecentric.com/invoice'],
-            'public https host, other domain' => ['https://api.example.com/invoice'],
+            // Literal IPs only - a hostname here would depend on live DNS
+            // resolution succeeding in whatever environment runs this test.
             'public ipv4 literal' => ['https://8.8.8.8/invoice'],
             'public ipv6 literal' => ['https://[2001:4860:4860::8888]/invoice'],
         ];

--- a/Test/Unit/Model/System/Config/Backend/UrlTest.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlTest.php
@@ -31,6 +31,8 @@ class UrlTest extends TestCase
             'empty value is allowed' => [''],
             'public https host' => ['https://api.tradecentric.com/invoice'],
             'public https host, other domain' => ['https://api.example.com/invoice'],
+            'public ipv4 literal' => ['https://8.8.8.8/invoice'],
+            'public ipv6 literal' => ['https://[2001:4860:4860::8888]/invoice'],
         ];
     }
 
@@ -60,6 +62,9 @@ class UrlTest extends TestCase
             'private ip 172.16.x' => ['https://172.16.0.5/invoice'],
             'private ip 192.168.x' => ['https://192.168.0.5/invoice'],
             'unresolvable host' => ['https://this-host-should-not-resolve.invalid/invoice'],
+            'ipv6 loopback literal' => ['https://[::1]/invoice'],
+            'ipv6 link-local literal' => ['https://[fe80::1]/invoice'],
+            'ipv6 unique-local literal' => ['https://[fd00::1]/invoice'],
         ];
     }
 

--- a/Test/Unit/Model/System/Config/Backend/UrlTest.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace TradeCentric\Invoice\Test\Unit\Model\System\Config\Backend;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use TradeCentric\Invoice\Model\System\Config\Backend\Url;
+
+class UrlTest extends TestCase
+{
+    /**
+     * @param string $value
+     * @return void
+     * @dataProvider validUrlDataProvider
+     */
+    public function testBeforeSaveAllowsValidUrl(string $value): void
+    {
+        $model = $this->createModel($value);
+        $model->beforeSave();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array
+     */
+    public function validUrlDataProvider(): array
+    {
+        return [
+            'empty value is allowed' => [''],
+            'public https host' => ['https://api.tradecentric.com/invoice'],
+            'public https host, other domain' => ['https://api.example.com/invoice'],
+        ];
+    }
+
+    /**
+     * @param string $value
+     * @return void
+     * @dataProvider invalidUrlDataProvider
+     */
+    public function testBeforeSaveRejectsInvalidUrl(string $value): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->createModel($value)->beforeSave();
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidUrlDataProvider(): array
+    {
+        return [
+            'not a url' => ['not-a-url'],
+            'disallowed scheme: file' => ['file:///etc/passwd'],
+            'disallowed scheme: plain http' => ['http://api.example.com/invoice'],
+            'loopback ip' => ['https://127.0.0.1/invoice'],
+            'link-local ip' => ['https://169.254.169.254/latest/meta-data'],
+            'private ip 10.x' => ['https://10.0.0.5/invoice'],
+            'private ip 172.16.x' => ['https://172.16.0.5/invoice'],
+            'private ip 192.168.x' => ['https://192.168.0.5/invoice'],
+            'unresolvable host' => ['https://this-host-should-not-resolve.invalid/invoice'],
+        ];
+    }
+
+    /**
+     * @param string $value
+     * @return Url
+     */
+    private function createModel(string $value): Url
+    {
+        $objectManager = new ObjectManager($this);
+        /** @var Url $model */
+        $model = $objectManager->getObject(Url::class);
+        $model->setValue($value);
+
+        return $model;
+    }
+}

--- a/Test/Unit/Model/System/Config/Backend/UrlWithStubbedDns.php
+++ b/Test/Unit/Model/System/Config/Backend/UrlWithStubbedDns.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace TradeCentric\Invoice\Test\Unit\Model\System\Config\Backend;
+
+use TradeCentric\Invoice\Model\System\Config\Backend\Url;
+
+/**
+ * Test double that returns a canned DNS resolution result instead of
+ * performing a real lookup, so the "hostname resolves to a public/private
+ * IP" behavior can be tested deterministically without live DNS.
+ */
+class UrlWithStubbedDns extends Url
+{
+    /**
+     * @var string[]
+     */
+    private $stubbedIps = [];
+
+    /**
+     * @param string[] $ips
+     * @return void
+     */
+    public function setStubbedIps(array $ips): void
+    {
+        $this->stubbedIps = $ips;
+    }
+
+    /**
+     * @param string $host
+     * @return string[]
+     */
+    protected function resolveHost(string $host): array
+    {
+        return $this->stubbedIps;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-  "version": "3.1.4",  
+  "version": "3.1.5",
   "require": {
     "php": "^7.0||^8.0",
     "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "tradecentric/module-punchout",
-            "version": "3.1.19",
+            "version": "3.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tradecentric/Magento_PunchOut.git",
-                "reference": "21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6"
+                "reference": "23a4b03b9d29fb7054448fcefa0d69c3007f321b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tradecentric/Magento_PunchOut/zipball/21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6",
-                "reference": "21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6",
+                "url": "https://api.github.com/repos/tradecentric/Magento_PunchOut/zipball/23a4b03b9d29fb7054448fcefa0d69c3007f321b",
+                "reference": "23a4b03b9d29fb7054448fcefa0d69c3007f321b",
                 "shasum": ""
             },
             "require": {
@@ -46,28 +46,33 @@
             ],
             "description": "TradeCentric PunchOut",
             "support": {
-                "source": "https://github.com/tradecentric/Magento_PunchOut/tree/3.1.19"
+                "source": "https://github.com/tradecentric/Magento_PunchOut/tree/3.1.21"
             },
-            "time": "2026-07-16T12:53:13+00:00"
+            "time": "2026-08-10T12:40:26+00:00"
         },
         {
             "name": "tradecentric/module-purchase-order",
-            "version": "3.0.14",
+            "version": "3.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tradecentric/Magento_PurchaseOrder.git",
-                "reference": "6fe893e8e3f39957a6bf16cbcbba3d8d8fcc1850"
+                "reference": "27b06e0f9571fccf0a43f4e97bfeda899d959088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tradecentric/Magento_PurchaseOrder/zipball/6fe893e8e3f39957a6bf16cbcbba3d8d8fcc1850",
-                "reference": "6fe893e8e3f39957a6bf16cbcbba3d8d8fcc1850",
+                "url": "https://api.github.com/repos/tradecentric/Magento_PurchaseOrder/zipball/27b06e0f9571fccf0a43f4e97bfeda899d959088",
+                "reference": "27b06e0f9571fccf0a43f4e97bfeda899d959088",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0||^8.0",
                 "tradecentric/module-punchout": "*",
                 "tradecentric/module-version": "*"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "magento/magento-coding-standard": "*",
+                "squizlabs/php_codesniffer": "^3.9"
             },
             "type": "magento2-module",
             "autoload": {
@@ -85,9 +90,9 @@
             ],
             "description": "TradeCentric Purchase Order",
             "support": {
-                "source": "https://github.com/tradecentric/Magento_PurchaseOrder/tree/3.0.14"
+                "source": "https://github.com/tradecentric/Magento_PurchaseOrder/tree/3.0.17"
             },
-            "time": "2025-08-12T14:10:03+00:00"
+            "time": "2026-08-10T12:57:58+00:00"
         },
         {
             "name": "tradecentric/module-version",
@@ -346,16 +351,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -435,15 +440,15 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.5",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -499,25 +504,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-05T06:31:06+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.5.7",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3"
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ba22f8c087848278fed6b4910d4cf1108096d8d3",
-                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.2.2"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -551,7 +556,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.7"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
             },
             "funding": [
                 {
@@ -559,20 +564,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-13T15:24:18+00:00"
+            "time": "2026-08-03T17:30:34+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -638,20 +643,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.34.0",
+            "version": "v15.37.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f"
+                "reference": "8c620457202b5c8d81582338238f769790ef718a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/c72fd0f82e7b992aaf35516ebf860a4729be206f",
-                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/8c620457202b5c8d81582338238f769790ef718a",
+                "reference": "8c620457202b5c8d81582338238f769790ef718a",
                 "shasum": ""
             },
             "require": {
@@ -664,14 +669,14 @@
                 "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.95.11",
+                "friendsofphp/php-cs-fixer": "3.95.17",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.2.5",
+                "phpstan/phpstan": "2.2.6",
                 "phpstan/phpstan-phpunit": "2.0.18",
-                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpstan/phpstan-strict-rules": "2.0.12",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
@@ -706,7 +711,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.34.0"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.37.1"
             },
             "funding": [
                 {
@@ -718,7 +723,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-07-05T18:03:26+00:00"
+            "time": "2026-07-29T07:35:47+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14adb841e6ec0188ba90effe9737a5a4",
+    "content-hash": "b2e051acb721d31f6adde7ca7f43e0c6",
     "packages": [
         {
             "name": "tradecentric/module-punchout",
-            "version": "3.1.16",
+            "version": "3.1.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tradecentric/Magento_PunchOut.git",
-                "reference": "765609e77a51d6de65b110979a7c936dde8a0b27"
+                "reference": "21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tradecentric/Magento_PunchOut/zipball/765609e77a51d6de65b110979a7c936dde8a0b27",
-                "reference": "765609e77a51d6de65b110979a7c936dde8a0b27",
+                "url": "https://api.github.com/repos/tradecentric/Magento_PunchOut/zipball/21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6",
+                "reference": "21f5dce8b73c3f316b1e0c7b3bcbcb00a9101af6",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "php": "~7.3.0||~7.4.0||^8.0",
                 "tradecentric/module-version": "*"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "magento/magento-coding-standard": "*",
+                "squizlabs/php_codesniffer": "^3.9"
             },
             "type": "magento2-module",
             "autoload": {
@@ -41,9 +46,9 @@
             ],
             "description": "TradeCentric PunchOut",
             "support": {
-                "source": "https://github.com/tradecentric/Magento_PunchOut/tree/3.1.16"
+                "source": "https://github.com/tradecentric/Magento_PunchOut/tree/3.1.19"
             },
-            "time": "2026-05-18T07:07:34+00:00"
+            "time": "2026-07-16T12:53:13+00:00"
         },
         {
             "name": "tradecentric/module-purchase-order",
@@ -434,11 +439,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.55",
+            "version": "2.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
-                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
                 "shasum": ""
             },
             "require": {
@@ -460,6 +465,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -483,25 +499,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T11:57:34+00:00"
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.4.4",
+            "version": "2.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "4661c582a20f03df585d2e3fdc4af1b83d67a091"
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/4661c582a20f03df585d2e3fdc4af1b83d67a091",
-                "reference": "4661c582a20f03df585d2e3fdc4af1b83d67a091",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ba22f8c087848278fed6b4910d4cf1108096d8d3",
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.48"
+                "phpstan/phpstan": "^2.2.2"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -535,7 +551,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.4"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.7"
             },
             "funding": [
                 {
@@ -543,7 +559,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-20T19:30:21+00:00"
+            "time": "2026-07-13T15:24:18+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -626,16 +642,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.32.3",
+            "version": "v15.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
+                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
-                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/c72fd0f82e7b992aaf35516ebf860a4729be206f",
+                "reference": "c72fd0f82e7b992aaf35516ebf860a4729be206f",
                 "shasum": ""
             },
             "require": {
@@ -648,14 +664,14 @@
                 "amphp/http-server": "^2.1 || ^3",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.95.1",
+                "friendsofphp/php-cs-fixer": "3.95.11",
                 "mll-lab/php-cs-fixer-config": "5.13.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.51",
-                "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.10",
+                "phpstan/phpstan": "2.2.5",
+                "phpstan/phpstan-phpunit": "2.0.18",
+                "phpstan/phpstan-strict-rules": "2.0.11",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
@@ -690,7 +706,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.34.0"
             },
             "funding": [
                 {
@@ -702,7 +718,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-24T13:49:35+00:00"
+            "time": "2026-07-05T18:03:26+00:00"
         }
     ],
     "aliases": [],
@@ -714,5 +730,5 @@
         "php": "^7.0||^8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -12,6 +12,7 @@
                 <label>Invoice Path</label>
                 <field id="url" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Url</label>
+                    <backend_model>TradeCentric\Invoice\Model\System\Config\Backend\Url</backend_model>
                 </field>
                 <field id="key" translate="label comment" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>API Key</label>


### PR DESCRIPTION
## Summary
- Adds config-save validation requiring the TradeCentric invoice URL to use `https` and rejecting private/loopback/link-local/reserved hosts (mitigates SSRF via config misconfiguration)
- Explicitly enforces TLS certificate verification (`verify: true`) on the outbound Guzzle request in InvoiceSender (mitigates MITM)
- Adds unit test coverage for the new URL validator

## Context
Addresses the SonarQube (AZJI1MFURW4NQ3bgpPGj) / GitHub code-scanning (#1) SSRF finding on `InvoiceSender.php`. Full triage and risk discussion in CN-804.

## Test plan
- [ ] See manual QA test plan posted on CN-804
- [ ] Unit tests: `Test/Unit/Model/System/Config/Backend/UrlTest.php`