### PR TITLE
Update CODEOWNERS to change default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,15 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, specified owners will be requested for review when someone opens a pull request.
 *       @tradecentric/ui-connectors-software-engineer
+
+# CODEOWNERS file itself is owned Product Release Management
+CODEOWNERS                 @tradecentric/product-best-practices
+
+# CI/CD configuration files
+/.hadolint.yaml            @tradecentric/product-best-practices
+/rector.php                @tradecentric/product-best-practices
+/.php-cs-fixer.php         @tradecentric/product-best-practices
+/phpstan.neon              @tradecentric/product-best-practices
+/phpunit.xml               @tradecentric/product-best-practices
+/sonar-project.properties  @tradecentric/product-best-practices
+/deptrac.yaml              @tradecentric/product-best-practices

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @tradecentric/product-endpoint-dev-engineer
+*       @tradecentric/ui-connectors-software-engineer


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to clarify and reorganize code ownership for the repository. The changes set new default owners, specify ownership for key configuration files, and improve documentation within the file.

Ownership and documentation updates:

* Set `@tradecentric/ui-connectors-software-engineer` as the default owner for all files in the repository, replacing the previous default owner.
* Assigned `@tradecentric/product-best-practices` as the owner for the `CODEOWNERS` file itself and for various CI/CD and configuration files, including `.hadolint.yaml`, `rector.php`, `.php-cs-fixer.php`, `phpstan.neon`, `phpunit.xml`, `sonar-project.properties`, and `deptrac.yaml`.
* Improved comments to clarify the purpose of each ownership rule and the precedence of matches.